### PR TITLE
Adding the ability to create links in the Grid

### DIFF
--- a/lib/components/List/Grid/index.jsx
+++ b/lib/components/List/Grid/index.jsx
@@ -1,31 +1,60 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import flatten from 'flat';
+import { Link } from 'react-router-dom';
 import Wireframe from './Wireframe';
+
+// eslint-disable-next-line
+const renderOnClick = ({ column, flattenedItem }) => (
+  // eslint-disable-next-line
+  <span
+    onClick={() => column.onClick(flattenedItem[column.key])}
+    className="text-large link"
+  >
+    {flattenedItem[column.key]}
+  </span>
+);
+
+// eslint-disable-next-line
+const renderLink = ({ column, flattenedItem }) => {
+
+  const linkKey = column.link.key;
+  const linkUrl = `${column.link.url}/${flattenedItem[linkKey]}`;
+
+  return (
+      // eslint-disable-next-line
+      <Link to={linkUrl} className="text-large link">
+        {flattenedItem[column.key]}
+      </Link>
+  );
+};
 
 const renderListColumns = ({ keyMap, item }) => {
   const flattenedItem = flatten(item);
 
-  return keyMap.map(column => (
-    <p
-      key={Math.random()}
-      className="pull-left"
-      style={{ width: '20%', marginBottom: '15px' }}
-    >
-      {
-      column.onClick ?
-        // eslint-disable-next-line
-        <span
-          onClick={() => column.onClick(flattenedItem[column.key])}
-          className="text-large link"
-        >
-          {flattenedItem[column.key]}
-        </span> :
-        <span className="text-large">{flattenedItem[column.key]}</span>
-    }
-      <br />
-      <span className="text-muted">{column.text || column.key}</span>
-    </p>));
+  return keyMap.map((column) => {
+    // text for the link will be rendered with the action if there is one
+    const hasActions = column.onClick || column.link;
+
+    return (
+      <p
+        key={Math.random()}
+        className="pull-left"
+        style={{ width: '20%', marginBottom: '15px' }}
+      >
+        {
+        column.onClick ? renderOnClick({ column, flattenedItem }) : ''
+      }
+        {
+        column.link ? renderLink({ column, flattenedItem }) : ''
+      }
+        {
+        !hasActions ? <span className="text-large">{flattenedItem[column.key]}</span> : ''
+      }
+        <br />
+        <span className="text-muted">{column.text || column.key}</span>
+      </p>);
+  });
 };
 
 const Grid = ({
@@ -51,6 +80,10 @@ Grid.propTypes = {
   classes: PropTypes.string,
   items: PropTypes.arrayOf(PropTypes.shape({
     onClick: PropTypes.func,
+    link: PropTypes.shape({
+      url: PropTypes.string,
+      key: PropTypes.string,
+    }),
     key: PropTypes.string,
     text: PropTypes.string,
   })).isRequired,

--- a/lib/components/List/list.stories.js
+++ b/lib/components/List/list.stories.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Route, BrowserRouter } from 'react-router-dom';
 import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 import Grid from './Grid';
@@ -39,6 +40,17 @@ const nestedGridData = [
   },
 ];
 
+const linkGridData = [
+  {
+    linkDesc: 'Link Item one x',
+    linkKey: '12345',
+  },
+  {
+    linkDesc: 'Link Item two x',
+    linkKey: '6789',
+  },
+];
+
 const testKeyMap = [
   { onClick: () => {}, key: 'keyOne', text: 'Test Key One' },
   { key: 'keyThree', text: 'Test Key three' },
@@ -66,6 +78,30 @@ stories.add('Nested Data Grid List', () => (
     <Component>
       <Grid items={nestedGridData} keyMap={[{ key: 'nestedKeys.keyFive', text: 'This is displaying nested data' }]} />
     </Component>
+  </UI>
+));
+
+stories.add('URL Links Data Grid List', () => (
+  <UI>
+    <BrowserRouter>
+      <main>
+        <Route path="/test" component={Component} />
+        <Component>
+          <Grid
+            items={linkGridData}
+            keyMap={[{
+              key: 'linkDesc',
+              text: 'This is displaying a href link',
+              link: {
+                url: '/test',
+                key: 'linkKey',
+              },
+            },
+            ]}
+          />
+        </Component>
+      </main>
+    </BrowserRouter>
   </UI>
 ));
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
+    "react-router-dom": "^4.2.2",
+    "history": "^4.7.2",
     "react-storybook-addon-props-combinations": "^1.0.1",
     "react-test-renderer": "^16.2.0",
     "node-sass-chokidar": "0.0.3"


### PR DESCRIPTION
Example keyMap to make this work added to stories:

keyMap={[{
              key: 'linkDesc',
              text: 'This is displaying a href link',
              link: {
                url: '/test',
                key: 'linkKey',
              },
            }