### PR TITLE
Allow Grid link to work with URL patterns

### DIFF
--- a/lib/components/List/Grid/index.jsx
+++ b/lib/components/List/Grid/index.jsx
@@ -17,9 +17,9 @@ const renderOnClick = ({ column, flattenedItem }) => (
 
 // eslint-disable-next-line
 const renderLink = ({ column, flattenedItem }) => {
-
-  const linkKey = column.link.key;
-  const linkUrl = `${column.link.url}/${flattenedItem[linkKey]}`;
+  const linkUrl = column.link.key
+    ? `${column.link.url}/${flattenedItem[column.link.key]}`
+    : column.link.url.replace(/{([^{]+)}/g, (match, attribute) => flattenedItem[attribute]);
 
   return (
     // eslint-disable-next-line


### PR DESCRIPTION
* This is also backward compatible with the previous version which appended 'key' to the end
  